### PR TITLE
feat: inital state set, default org, routing improvements

### DIFF
--- a/modules/auth/components/LoginForm/LoginForm.tsx
+++ b/modules/auth/components/LoginForm/LoginForm.tsx
@@ -2,10 +2,7 @@ import { useSignIn } from '@modules/auth';
 import { ApplicationError } from '@modules/auth/utils/Errors';
 import { handleTokenFromQueryString } from '@modules/auth/utils/handleTokenFromQueryString';
 import { useGetBlockchains } from '@modules/node';
-import {
-  useDefaultOrganization,
-  useGetOrganizations,
-} from '@modules/organization';
+import { useGetOrganizations } from '@modules/organization';
 import { Alert, Button, Input } from '@shared/components';
 import { ROUTES } from '@shared/index';
 import { isValidEmail } from '@shared/utils/validation';
@@ -25,7 +22,7 @@ type LoginForm = {
 };
 
 export function LoginForm() {
-  const { organizations, getOrganizations } = useGetOrganizations();
+  const { getOrganizations } = useGetOrganizations();
   const router = useRouter();
   const { invited, verified, redirect, token } = router.query;
   const signIn = useSignIn();
@@ -34,7 +31,6 @@ export function LoginForm() {
   const [loading, setIsLoading] = useState(false);
   const [loginError, setLoginError] = useState<string | undefined>(undefined);
   const [activeType, setActiveType] = useState<'password' | 'text'>('password');
-  const { getDefaultOrganization } = useDefaultOrganization();
   const { getBlockchains } = useGetBlockchains();
 
   const handleIconClick = () => {
@@ -61,7 +57,7 @@ export function LoginForm() {
 
     try {
       await signIn(email, password);
-      await getOrganizations();
+      await getOrganizations(true);
       await getBlockchains();
 
       handleRedirect();
@@ -72,12 +68,6 @@ export function LoginForm() {
       setIsLoading(false);
     }
   });
-
-  useEffect(() => {
-    if (organizations.length) {
-      getDefaultOrganization();
-    }
-  }, [organizations]);
 
   useEffect(() => {
     if (router.isReady) {

--- a/modules/auth/components/PublicRoute/PublicRoute.tsx
+++ b/modules/auth/components/PublicRoute/PublicRoute.tsx
@@ -19,12 +19,6 @@ export function PublicRoute({ children }: Props) {
     }
   }, []);
 
-  if (isLoading) {
-    return <LoadingSpinner size="page" />;
-  }
-
-  if (isLoggedIn) return null;
-
   return (
     <>
       {window.navigator.onLine ? (

--- a/modules/auth/hooks/useSignIn.ts
+++ b/modules/auth/hooks/useSignIn.ts
@@ -1,12 +1,12 @@
 import { apiClient } from '@modules/client';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { authAtoms } from '../store/authAtoms';
 import { isSuccess } from '../utils/authTypeGuards';
 import { ApplicationError } from '../utils/Errors';
 import { useIdentityRepository } from './useIdentityRepository';
 
 export function useSignIn() {
-  const [, setUser] = useRecoilState(authAtoms.user);
+  const setUser = useSetRecoilState(authAtoms.user);
   const repository = useIdentityRepository();
 
   const signIn = async (email: string, password: string) => {
@@ -22,7 +22,11 @@ export function useSignIn() {
 
       const userData: any = await apiClient.getUser();
       repository?.updateIdentity(userData);
-      setUser((current) => ({ ...current, ...userData }));
+      setUser((current) => ({
+        ...current,
+        ...userData,
+        accessToken: response.value,
+      }));
     } else {
       throw new ApplicationError('LoginError', response?.message ?? '');
     }

--- a/modules/node/components/NodeView/NodeView.tsx
+++ b/modules/node/components/NodeView/NodeView.tsx
@@ -16,6 +16,7 @@ import {
 import { spacing } from 'styles/utils.spacing.styles';
 import { NodeViewDetailsHeader } from './NodeViewDetailsHeader';
 import { NodeViewConfig } from './NodeViewConfig';
+import { ROUTES } from '@shared/index';
 
 export function NodeView() {
   const [isMounted, setMounted] = useState<boolean>(false);
@@ -48,7 +49,7 @@ export function NodeView() {
       <PageSection topPadding={false}>
         <div css={spacing.top.medium}>
           <PageHeader>
-            <BackButton />
+            <BackButton backUrl={ROUTES.NODES} />
           </PageHeader>
         </div>
 

--- a/modules/organization/components/OrganizationView/OrganizationView.tsx
+++ b/modules/organization/components/OrganizationView/OrganizationView.tsx
@@ -18,11 +18,19 @@ import {
 import { useDeleteOrganization } from '@modules/organization/hooks/useDeleteOrganization';
 import { useGetOrganization } from '@modules/organization/hooks/useGetOrganization';
 import { Members } from './OrganizationMembers/OrganizationMembers';
-import { organizationAtoms, useInvitations, useUpdateOrganization } from '@modules/organization';
-import { Permissions, useHasPermissions } from '@modules/auth/hooks/useHasPermissions';
+import {
+  organizationAtoms,
+  useInvitations,
+  useUpdateOrganization,
+} from '@modules/organization';
+import {
+  Permissions,
+  useHasPermissions,
+} from '@modules/auth/hooks/useHasPermissions';
 import { useLeaveOrganization } from '@modules/organization/hooks/useLeaveOrganization';
 import { useRecoilValue } from 'recoil';
 import { useGetOrganizationMembers } from '@modules/organization/hooks/useGetMembers';
+import { ROUTES } from '@shared/index';
 
 export const OrganizationView = () => {
   const router = useRouter();
@@ -32,8 +40,12 @@ export const OrganizationView = () => {
   const { updateOrganization } = useUpdateOrganization();
   const { leaveOrganization } = useLeaveOrganization();
 
-  const sentInvitationsLoadingState = useRecoilValue(organizationAtoms.organizationSentInvitationsLoadingState);
-  const membersLoadingState = useRecoilValue(organizationAtoms.organizationMembersLoadingState);
+  const sentInvitationsLoadingState = useRecoilValue(
+    organizationAtoms.organizationSentInvitationsLoadingState,
+  );
+  const membersLoadingState = useRecoilValue(
+    organizationAtoms.organizationMembersLoadingState,
+  );
 
   const [isSavingOrganization, setIsSavingOrganization] =
     useState<boolean>(false);
@@ -49,8 +61,14 @@ export const OrganizationView = () => {
     }
   };
 
-  const canUpdateOrganization: boolean = useHasPermissions(organization?.currentUser?.role!, Permissions.UPDATE_ORGANIZATION);
-  const canDeleteOrganization: boolean = useHasPermissions(organization?.currentUser?.role!, Permissions.DELETE_ORGANIZATION);
+  const canUpdateOrganization: boolean = useHasPermissions(
+    organization?.currentUser?.role!,
+    Permissions.UPDATE_ORGANIZATION,
+  );
+  const canDeleteOrganization: boolean = useHasPermissions(
+    organization?.currentUser?.role!,
+    Permissions.DELETE_ORGANIZATION,
+  );
 
   const action = canDeleteOrganization ? 'delete' : 'leave';
 
@@ -62,10 +80,8 @@ export const OrganizationView = () => {
     }
   };
 
-  const {
-    getOrganizationMembers,
-    organizationMembers,
-  } = useGetOrganizationMembers();
+  const { getOrganizationMembers, organizationMembers } =
+    useGetOrganizationMembers();
 
   const { getSentInvitations, sentInvitations } = useInvitations();
 
@@ -78,14 +94,17 @@ export const OrganizationView = () => {
   }, [router.isReady]);
 
   const details = getOrganizationDetails(organization);
-  const isLoadingOrg = isLoading !== 'finished' || membersLoadingState !== 'finished' || sentInvitationsLoadingState !== 'finished';
+  const isLoadingOrg =
+    isLoading !== 'finished' ||
+    membersLoadingState !== 'finished' ||
+    sentInvitationsLoadingState !== 'finished';
 
   return (
     <>
       <PageTitle title="Organizations" />
       <PageSection>
         <div css={spacing.top.medium}>
-          <BackButton />
+          <BackButton backUrl={ROUTES.ORGANIZATIONS} />
         </div>
         {isLoadingOrg ? (
           <div css={spacing.top.medium}>
@@ -105,7 +124,11 @@ export const OrganizationView = () => {
             />
             <DetailsTable bodyElements={details ?? []} />
             <div css={[spacing.top.xLarge]} />
-            <Members members={organizationMembers} invitations={sentInvitations} id={queryAsString(id)} />
+            <Members
+              members={organizationMembers}
+              invitations={sentInvitations}
+              id={queryAsString(id)}
+            />
           </div>
         )}
       </PageSection>

--- a/modules/organization/hooks/useDefaultOrganization.ts
+++ b/modules/organization/hooks/useDefaultOrganization.ts
@@ -12,9 +12,9 @@ export function useDefaultOrganization() {
     organizationAtoms.defaultOrganization,
   );
 
-  const organizations = useRecoilValue(organizationAtoms.allOrganizations);
-
-  const getDefaultOrganization = async () => {
+  const getDefaultOrganization = async (
+    organizations: ClientOrganization[],
+  ) => {
     setLoadingState('loading');
 
     const identity = repository?.getIdentity();
@@ -22,14 +22,11 @@ export function useDefaultOrganization() {
     const userData: any = user?.data;
     const orgId = userData.org_id ?? '';
 
-    const organization = organizations.find(org => org.id === orgId);
+    const organization = organizations.find((org) => org.id === orgId);
 
     const orgName = organization?.name ?? '';
 
-    repository?.saveDefaultOrganization(
-      orgName,
-      orgId
-    );
+    repository?.saveDefaultOrganization(orgName, orgId);
 
     setDefaultOrganization({
       name: orgName,

--- a/modules/organization/hooks/useGetOrganizations.ts
+++ b/modules/organization/hooks/useGetOrganizations.ts
@@ -1,6 +1,7 @@
 import { apiClient } from '@modules/client';
 import { useRecoilState } from 'recoil';
 import { organizationAtoms } from '../store/organizationAtoms';
+import { useDefaultOrganization } from './useDefaultOrganization';
 
 export function useGetOrganizations() {
   const [organizations, setOrganizations] = useRecoilState(
@@ -14,10 +15,15 @@ export function useGetOrganizations() {
     organizationAtoms.organizationsPageIndex,
   );
 
-  const getOrganizations = async () => {
+  const { getDefaultOrganization } = useDefaultOrganization();
+
+  const getOrganizations = async (init: boolean) => {
     setIsLoading('initializing');
     const organizations: any = await apiClient.getOrganizations();
     setOrganizations(organizations);
+
+    if (init) getDefaultOrganization(organizations);
+
     setIsLoading('finished');
   };
 

--- a/shared/components/BackButton/BackButton.tsx
+++ b/shared/components/BackButton/BackButton.tsx
@@ -3,9 +3,14 @@ import IconBack from '@public/assets/icons/arrow-left-12.svg';
 import router from 'next/router';
 import { Button } from '../Button/Button';
 
-export const BackButton: FC = ({}) => {
+export type BackButtonProps = {
+  backUrl?: string;
+};
+
+export const BackButton = ({ backUrl }: BackButtonProps) => {
   function handleClick() {
-    router.back();
+    if (backUrl) router.push(backUrl, undefined, { shallow: true });
+    else router.back();
   }
 
   return (

--- a/shared/constants/routes.ts
+++ b/shared/constants/routes.ts
@@ -6,6 +6,9 @@ export const ROUTES = {
   NODES: '/nodes',
   NODE_GROUP: (id: string) => `/nodes/group/${id}`,
   LOGIN: '/login',
+  ORGANIZATIONS: '/organizations',
   REGISTER: '/register',
   FORGOT_PASSWORD: '/forgot-password',
 };
+
+export const PUBLIC_ROUTES = ['/login'];


### PR DESCRIPTION
- The Access token is now set in the SignIn hook, which reduces some re-renders
- Default org is set when initially retrieved organizations
- Reload after re-routing is fixed
- Added loading spinner to the login button form until log in is complete (pls improve design)
- Added backUrl prop to back button which resolves reloading and redirects to back to proper pages