### PR TITLE
fix: [sc-2438] cherry-picked lodash methods

### DIFF
--- a/modules/host/components/HostList/HostList.tsx
+++ b/modules/host/components/HostList/HostList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { useRecoilValue } from 'recoil';
 import {
   TableSkeleton,

--- a/modules/host/hooks/useFilters.ts
+++ b/modules/host/hooks/useFilters.ts
@@ -4,7 +4,7 @@ import {
 } from '@modules/organization';
 import { useSwitchOrganization } from '@modules/organization/hooks/useSwitchOrganization';
 import { hostFiltersDefaults } from '@shared/constants/lookups';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { useRecoilState } from 'recoil';
 import { hostAtoms } from '../store/hostAtoms';
 import { HostUIProps } from '../ui/HostUIContext';

--- a/modules/host/store/hostSelectors.ts
+++ b/modules/host/store/hostSelectors.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { hostFiltersDefaults } from '@shared/constants/lookups';
 import { selector } from 'recoil';
 import { hostAtoms } from './hostAtoms';

--- a/modules/host/ui/HostUIContext.tsx
+++ b/modules/host/ui/HostUIContext.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useState, useCallback, createContext } from 'react';
-import { isEqual, isFunction } from 'lodash';
+import isEqual from 'lodash/isEqual';
+import isFunction from 'lodash/isFunction';
 import { initialQueryParams, InitialQueryParams } from './HostUIHelpers';
 import { loadPersistedFilters } from '../utils/loadPersistedFilters';
 import { buildParams } from '../utils/buildParams';

--- a/modules/node/components/NodeList/NodeList.tsx
+++ b/modules/node/components/NodeList/NodeList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useRecoilValue } from 'recoil';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { useNodeList } from '@modules/node/hooks/useNodeList';
 import { nodeAtoms } from '@modules/node/store/nodeAtoms';
 import {

--- a/modules/node/hooks/useFilters.ts
+++ b/modules/node/hooks/useFilters.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { nodeAtoms } from '../store/nodeAtoms';
 import { NodeUIProps } from '../ui/NodeUIContext';

--- a/modules/node/ui/NodeUIContext.tsx
+++ b/modules/node/ui/NodeUIContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
-import { isEqual, isFunction } from 'lodash';
+import isEqual from 'lodash/isEqual';
+import isFunction from 'lodash/isFunction';
 import { InitialQueryParams, initialQueryParams } from './NodeUIHelpers';
 import {
   buildParams,

--- a/modules/organization/ui/OrganizationInvitationsUIContext.tsx
+++ b/modules/organization/ui/OrganizationInvitationsUIContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
-import { isEqual, isFunction } from 'lodash';
+import isEqual from 'lodash/isEqual';
+import isFunction from 'lodash/isFunction';
 import {
   InitialQueryParams,
   initialQueryParams,

--- a/modules/organization/ui/OrganizationMembersUIContext.tsx
+++ b/modules/organization/ui/OrganizationMembersUIContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
-import { isEqual, isFunction } from 'lodash';
+import isEqual from 'lodash/isEqual';
+import isFunction from 'lodash/isFunction';
 import {
   InitialQueryParams,
   initialQueryParams,

--- a/modules/organization/ui/OrganizationsUIContext.tsx
+++ b/modules/organization/ui/OrganizationsUIContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
-import { isEqual, isFunction } from 'lodash';
+import isEqual from 'lodash/isEqual';
+import isFunction from 'lodash/isFunction';
 import {
   InitialQueryParams,
   initialQueryParams,

--- a/shared/utils/escapeHtml.ts
+++ b/shared/utils/escapeHtml.ts
@@ -1,4 +1,4 @@
-// import { escape } from 'lodash';
+// import escape from 'lodash/escape';
 //export const escapeHtml = (unsafe: string) => escape(unsafe);
 
 export const escapeHtml = (unsafe: string) => {


### PR DESCRIPTION
@frontend-joe, let's continue importing `lodash` methods as cherry-picked. It reduces the bundle size.