### PR TITLE
feat: [sc-3427] preselect host on node launcher page

### DIFF
--- a/modules/node/hooks/useNodeLauncherHandlers.ts
+++ b/modules/node/hooks/useNodeLauncherHandlers.ts
@@ -50,7 +50,7 @@ export const useNodeLauncherHandlers = (): IUseNodeLauncherHandlersHook => {
   const defaultOrganization = useRecoilValue(
     organizationAtoms.defaultOrganization,
   );
-  const hostList = useRecoilValue(hostAtoms.hostList);
+  const allHosts = useRecoilValue(hostAtoms.allHosts);
   const blockchains = useRecoilValue(blockchainAtoms.blockchains);
   const setSelectedNodeType = useSetRecoilState(
     nodeLauncherAtoms.selectedNodeType,
@@ -85,8 +85,13 @@ export const useNodeLauncherHandlers = (): IUseNodeLauncherHandlersHook => {
   );
 
   useEffect(() => {
-    setSelectedHost(null);
-  }, [hostList]);
+    let queriedHost = null;
+    if (router.isReady && router.query.hostId)
+      queriedHost =
+        allHosts.find((host: Host) => host.id === router.query.hostId) ?? null;
+
+    setSelectedHost(queriedHost);
+  }, [allHosts, router.isReady]);
 
   const handleHostChanged = (host: Host | null) => {
     Mixpanel.track('Launch Node - Host Changed');

--- a/shared/components/App/Page/PageTitleLaunchNode.tsx
+++ b/shared/components/App/Page/PageTitleLaunchNode.tsx
@@ -5,9 +5,21 @@ import { SvgIcon } from '@shared/components';
 
 export const PageTitleLaunchNode = () => {
   const router = useRouter();
+  const query: { hostId?: string | string[] } = {};
+
+  if (router.query.id && router.pathname === '/hosts/[id]')
+    query.hostId = router.query.id;
 
   return !router.pathname.includes('launch-node') ? (
-    <button css={styles.button} onClick={() => router.push('/launch-node')}>
+    <button
+      css={styles.button}
+      onClick={() =>
+        router.push({
+          pathname: '/launch-node',
+          query,
+        })
+      }
+    >
       <SvgIcon size="20px">
         <IconRocket />
       </SvgIcon>


### PR DESCRIPTION
- passing hostId in query params from `/hosts/[id]` route
- preselecting the Host in case a query param `hostId` exists when landing on `NodeLauncher` component